### PR TITLE
Get streams from stream module in usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import pyrealsense as pyrs
 pyrs.start()
 
 ## create a device from device id and streams of interest
-cam = pyrs.Device(device_id = 0, streams = [pyrs.ColorStream(fps = 60)])
+cam = pyrs.Device(device_id = 0, streams = [pyrs.stream.ColorStream(fps = 60)])
 
 ## retrieve 60 frames of data
 for _ in range(60):

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Online Usage
     pyrs.start()
 
     ## create a device from device id and streams of interest
-    cam = pyrs.Device(device_id = 0, streams = [pyrs.ColorStream(fps = 60)])
+    cam = pyrs.Device(device_id = 0, streams = [pyrs.stream.ColorStream(fps = 60)])
 
     ## retrieve 60 frames of data
     for _ in range(60):


### PR DESCRIPTION
Looks like these aren't re-exported from stream since 2.0