### PR TITLE
Replace global context with single context per service instance

### DIFF
--- a/examples/show_cv2.py
+++ b/examples/show_cv2.py
@@ -5,7 +5,6 @@ import time
 import numpy as np
 import cv2
 import pyrealsense as pyrs
-from pyrealsense.stream import ColorStream, DepthStream
 
 
 with pyrs.Service() as serv:

--- a/examples/show_cv2.py
+++ b/examples/show_cv2.py
@@ -5,39 +5,41 @@ import time
 import numpy as np
 import cv2
 import pyrealsense as pyrs
+from pyrealsense.stream import ColorStream, DepthStream
 
 
-with pyrs.Service() as a, pyrs.Device() as dev:
+with pyrs.Service() as serv:
+    with serv.device() as dev:
 
-    dev.apply_ivcam_preset(0)
+        dev.apply_ivcam_preset(0)
 
-    cnt = 0
-    last = time.time()
-    smoothing = 0.9;
-    fps_smooth = 30
+        cnt = 0
+        last = time.time()
+        smoothing = 0.9;
+        fps_smooth = 30
 
-    while True:
+        while True:
 
-        cnt += 1
-        if (cnt % 10) == 0:
-            now = time.time()
-            dt = now - last
-            fps = 10/dt
-            fps_smooth = (fps_smooth * smoothing) + (fps * (1.0-smoothing))
-            last = now
+            cnt += 1
+            if (cnt % 10) == 0:
+                now = time.time()
+                dt = now - last
+                fps = 10/dt
+                fps_smooth = (fps_smooth * smoothing) + (fps * (1.0-smoothing))
+                last = now
 
-        dev.wait_for_frames()
-        c = dev.color
-        c = cv2.cvtColor(c, cv2.COLOR_RGB2BGR)
-        d = dev.depth * dev.depth_scale * 1000
-        d = cv2.applyColorMap(d.astype(np.uint8), cv2.COLORMAP_RAINBOW)
+            dev.wait_for_frames()
+            c = dev.color
+            c = cv2.cvtColor(c, cv2.COLOR_RGB2BGR)
+            d = dev.depth * dev.depth_scale * 1000
+            d = cv2.applyColorMap(d.astype(np.uint8), cv2.COLORMAP_RAINBOW)
 
-        cd = np.concatenate((c,d), axis=1)
+            cd = np.concatenate((c,d), axis=1)
 
-        cv2.putText(cd, str(fps_smooth)[:4], (0,50), cv2.FONT_HERSHEY_SIMPLEX, 2, (0,0,0))
+            cv2.putText(cd, str(fps_smooth)[:4], (0,50), cv2.FONT_HERSHEY_SIMPLEX, 2, (0,0,0))
 
-        cv2.imshow('', cd)
-        if cv2.waitKey(1) & 0xFF == ord('q'):
-            break
+            cv2.imshow('', cd)
+            if cv2.waitKey(1) & 0xFF == ord('q'):
+                break
 
-    # dev.stop()
+        # dev.stop()

--- a/examples/show_cv2.py
+++ b/examples/show_cv2.py
@@ -8,13 +8,13 @@ import pyrealsense as pyrs
 
 
 with pyrs.Service() as serv:
-    with serv.device() as dev:
+    with serv.Device() as dev:
 
         dev.apply_ivcam_preset(0)
 
         cnt = 0
         last = time.time()
-        smoothing = 0.9;
+        smoothing = 0.9
         fps_smooth = 30
 
         while True:
@@ -33,9 +33,9 @@ with pyrs.Service() as serv:
             d = dev.depth * dev.depth_scale * 1000
             d = cv2.applyColorMap(d.astype(np.uint8), cv2.COLORMAP_RAINBOW)
 
-            cd = np.concatenate((c,d), axis=1)
+            cd = np.concatenate((c, d), axis=1)
 
-            cv2.putText(cd, str(fps_smooth)[:4], (0,50), cv2.FONT_HERSHEY_SIMPLEX, 2, (0,0,0))
+            cv2.putText(cd, str(fps_smooth)[:4], (0, 50), cv2.FONT_HERSHEY_SIMPLEX, 2, (0, 0, 0))
 
             cv2.imshow('', cd)
             if cv2.waitKey(1) & 0xFF == ord('q'):

--- a/examples/show_matplotlib.py
+++ b/examples/show_matplotlib.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import pyrealsense as pyrs
 
 with pyrs.Service() as serv:
-    with serv.device() as dev:
+    with serv.Device() as dev:
         dev.wait_for_frames()
         plt.imshow(dev.color)
         plt.show()

--- a/examples/show_matplotlib.py
+++ b/examples/show_matplotlib.py
@@ -4,8 +4,8 @@ logging.basicConfig(level=logging.INFO)
 import matplotlib.pyplot as plt
 import pyrealsense as pyrs
 
-with pyrs.Service():
-    dev = pyrs.Device()
-    dev.wait_for_frames()
-    plt.imshow(dev.color)
-    plt.show()
+with pyrs.Service() as serv:
+    with serv.device() as dev:
+        dev.wait_for_frames()
+        plt.imshow(dev.color)
+        plt.show()

--- a/examples/show_vtk.py
+++ b/examples/show_vtk.py
@@ -8,8 +8,9 @@ import vtk.util.numpy_support as vtk_np
 
 
 import pyrealsense as pyrs
-pyrs.start()
-cam = pyrs.Device()
+serv = pyrs.Service()
+serv.start()
+cam = serv.device()
 
 
 class VTKActorWrapper(object):
@@ -108,3 +109,5 @@ def main():
 
 
 main()
+cam.stop()
+serv.stop()

--- a/examples/show_vtk.py
+++ b/examples/show_vtk.py
@@ -10,7 +10,7 @@ import vtk.util.numpy_support as vtk_np
 import pyrealsense as pyrs
 serv = pyrs.Service()
 serv.start()
-cam = serv.device()
+cam = serv.Device()
 
 
 class VTKActorWrapper(object):

--- a/pyrealsense/__init__.py
+++ b/pyrealsense/__init__.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import
 
-from .core import start, stop, Service, Device
+from .core import Service
 
-__version__ = '2.0'
-
+__version__ = '2.1'

--- a/pyrealsense/__init__.py
+++ b/pyrealsense/__init__.py
@@ -3,7 +3,6 @@
 """
 
 from __future__ import absolute_import
-
 from .core import Service
 
 __version__ = '2.1'

--- a/pyrealsense/core.py
+++ b/pyrealsense/core.py
@@ -7,61 +7,81 @@ logger.addHandler(logging.NullHandler())
 import ctypes
 import numpy as np
 from numpy.ctypeslib import ndpointer
-import warnings
 
-from .constants import RS_API_VERSION, rs_stream, rs_format
+from .constants import RS_API_VERSION, rs_stream
 from .stream import ColorStream, DepthStream, PointStream, CADStream, DACStream, InfraredStream
 from .extstruct import rs_error, rs_intrinsics, rs_extrinsics, rs_context, rs_device
 from .utils import pp, _check_error
 from .extlib import lrs, rsutilwrapper
 
 
-# Global variables
-e = ctypes.POINTER(rs_error)()
-ctx = 0
-
-
-def start():
-    """Start librealsense service."""
-    global ctx, e
-
-    # if not ctx:
-    lrs.rs_create_context.restype = ctypes.POINTER(rs_context)
-    ctx = lrs.rs_create_context(RS_API_VERSION, ctypes.byref(e))
-    _check_error(e)
-
-    n_devices = lrs.rs_get_device_count(ctx, ctypes.byref(e))
-    logger.info("There are {} connected RealSense devices.".format(n_devices))
-    _check_error(e)
-
-    return n_devices
-
-
-def stop():
-    """Stop librealsense service."""
-    global ctx, e
-
-    lrs.rs_delete_context(ctx, ctypes.byref(e))
-    _check_error(e)
-    ctx = 0
-
-
 class Service(object):
     """Context manager for librealsense service."""
+    def __init__(self):
+        super()
+        self.ctx = 0
+
+    def start(self):
+        """Start librealsense service."""
+        e = ctypes.POINTER(rs_error)()
+
+        # if not ctx:
+        lrs.rs_create_context.restype = ctypes.POINTER(rs_context)
+        self.ctx = lrs.rs_create_context(RS_API_VERSION, ctypes.byref(e))
+        _check_error(e)
+
+    def stop(self):
+        """Stop librealsense service."""
+        if self.ctx != 0:
+            e = ctypes.POINTER(rs_error)()
+            lrs.rs_delete_context(self.ctx, ctypes.byref(e))
+            _check_error(e)
+            self.ctx = 0
+
+    def get_devices(self):
+        e = ctypes.POINTER(rs_error)()
+        n_devices = lrs.rs_get_device_count(self.ctx, ctypes.byref(e))
+        _check_error(e)
+
+        lrs.rs_get_device.restype = ctypes.POINTER(rs_device)
+        for idx in range(n_devices):
+            dev = lrs.rs_get_device(self.ctx, idx, ctypes.byref(e))
+            _check_error(e)
+
+            name = pp(lrs.rs_get_device_name, dev, ctypes.byref(e))
+            _check_error(e)
+
+            serial = pp(lrs.rs_get_device_serial, dev, ctypes.byref(e))
+            _check_error(e)
+
+            version = pp(lrs.rs_get_device_firmware_version, dev, ctypes.byref(e))
+            _check_error(e)
+
+            yield {'id': idx, 'name': name, 'serial': serial, 'firmware': version}
+
+    def device(self, *args, **kwargs):
+        return Device(self, *args, **kwargs)
+
     def __enter__(self):
-        start()
+        if self.ctx == 0:
+            self.start()
+        return self
+
     def __exit__(self, *args):
         # print 'stopping the service'
-        stop()
+        self.stop()
+
+    def __del__(self):
+        self.stop()
 
 
-def Device(device_id=0, streams=None, depth_control_preset=None, ivcam_preset=None):
+def Device(service, device_id=0, streams=None, depth_control_preset=None, ivcam_preset=None):
     """Camera device, which subclass :class:`DeviceBase` and create properties for each input
     streams to expose their data.
 
     Args:
         device_id (int): the device id as hinted by the output from :func:`start`.
-        streams (:obj:`list` of :obj:`pyrealsense.stream.Stream`): if None, all streams will be 
+        streams (:obj:`list` of :obj:`pyrealsense.stream.Stream`): if None, all streams will be
             enabled with their default parameters (e.g `640x480@30FPS`)
         depth_control_preset (int): optional preset to be applied.
         ivcam_preset (int): optional preset to be applied with input value from
@@ -69,8 +89,10 @@ def Device(device_id=0, streams=None, depth_control_preset=None, ivcam_preset=No
     Returns:
         A subclass of :class:`DeviceBase` which class name includes the device serial number.
     """
+    e = ctypes.POINTER(rs_error)()
 
-    global ctx, e
+    assert service.ctx != 0, 'Service needs to be started'
+    ctx = service.ctx
 
     if streams is None:
         streams = [ColorStream(), DepthStream(), PointStream(), CADStream(), DACStream(), InfraredStream()]
@@ -92,37 +114,35 @@ def Device(device_id=0, streams=None, depth_control_preset=None, ivcam_preset=No
     logger.info("    Serial number: {}".format(serial))
     logger.info("    Firmware version: {}".format(version))
 
-    ## create a new class for the device
+    # create a new class for the device
     class_name = name.split(" ")[-1] + "-" + serial
     NewDevice = type(class_name, (DeviceBase,), dict())
 
     nd = NewDevice(dev, name, serial, version, streams)
 
-    ## enable the stream and start device
+    # enable the stream and start device
     for s in streams:
         if s.native:
-            lrs.rs_enable_stream(dev,
-                s.stream, s.width, s.height, s.format, s.fps,
-                ctypes.byref(e));
-            _check_error(e);
+            lrs.rs_enable_stream(dev, s.stream, s.width, s.height, s.format, s.fps, ctypes.byref(e))
+            _check_error(e)
 
     lrs.rs_start_device(dev, ctypes.byref(e))
 
-    ## depth control preset
+    # depth control preset
     if depth_control_preset:
         rsutilwrapper.apply_depth_control_preset(dev, depth_control_preset)
 
-    ## ivcam preset
+    # ivcam preset
     if ivcam_preset:
         rsutilwrapper.apply_ivcam_preset(dev, ivcam_preset)
 
-    ## add stream property and intrinsics
+    # add stream property and intrinsics
     for s in streams:
         if s.native:
             setattr(NewDevice, s.name + '_intrinsics', nd._get_stream_intrinsics(s.stream))
         setattr(NewDevice, s.name, property(nd._get_stream_data_closure(s)))
 
-    ## add manually depth_scale and manual pointcloud
+    # add manually depth_scale and manual pointcloud
     for s in streams:
         if s.name == 'depth':
             setattr(NewDevice, 'depth_scale', property(lambda x: nd._get_depth_scale()))
@@ -133,12 +153,12 @@ def Device(device_id=0, streams=None, depth_control_preset=None, ivcam_preset=No
 
 
 class DeviceBase(object):
-    """Camera device base class which should be called via the :func:`Device` factory. It 
+    """Camera device base class which should be called via the :func:`Device` factory. It
         exposes the main functions from librealsense.
     """
     def __init__(self, dev, name, serial, version, streams):
         super(DeviceBase, self).__init__()
-        global ctx, e
+        assert dev != 0, 'Device was not initialized correctly'
 
         self.dev = dev
         self.name = name
@@ -148,27 +168,34 @@ class DeviceBase(object):
 
     def __enter__(self):
         return self
+
     def __exit__(self, *args):
         self.stop()
 
+    def __del__(self):
+        self.stop()
 
     def stop(self):
         """End data acquisition.
-        Raises: 
+        Raises:
             :class:`utils.RealsenseError`: in case librealsense reports a problem.
         """
-        lrs.rs_stop_device(self.dev, ctypes.byref(e))
-        _check_error(e)
+        if self.dev != 0:
+            e = ctypes.POINTER(rs_error)()
+            lrs.rs_stop_device(self.dev, ctypes.byref(e))
+            _check_error(e)
+            self.dev = 0
 
     def poll_for_frame(self):
         """Check if new frames are available, without blocking.
 
         Returns:
             int: 1 if new frames are available, 0 if no new frames have arrived
-        
-        Raises: 
+
+        Raises:
             :class:`utils.RealsenseError`: in case librealsense reports a problem.
         """
+        e = ctypes.POINTER(rs_error)()
         res = lrs.rs_poll_for_frames(self.dev, ctypes.byref(e))
         _check_error(e)
         return res
@@ -176,9 +203,10 @@ class DeviceBase(object):
     def wait_for_frames(self):
         """Block until new frames are available.
 
-        Raises: 
+        Raises:
             :class:`utils.RealsenseError`: in case librealsense reports a problem.
         """
+        e = ctypes.POINTER(rs_error)()
         lrs.rs_wait_for_frames(self.dev, ctypes.byref(e))
         _check_error(e)
 
@@ -192,6 +220,7 @@ class DeviceBase(object):
             (long): timestamp
         """
         lrs.rs_get_frame_timestamp.restype = ctypes.c_double
+        e = ctypes.POINTER(rs_error)()
         return lrs.rs_get_frame_timestamp(self.dev, stream, ctypes.byref(e))
 
     def get_frame_number(self, stream):
@@ -204,6 +233,7 @@ class DeviceBase(object):
             (double): frame number.
         """
         lrs.rs_get_frame_number.restype = ctypes.c_ulonglong
+        e = ctypes.POINTER(rs_error)()
         return lrs.rs_get_frame_number(self.dev, stream, ctypes.byref(e))
 
     def get_device_extrinsics(self, from_stream, to_stream):
@@ -217,6 +247,7 @@ class DeviceBase(object):
             (:class:`pyrealsense.extstruct.rs_extrinsics`): extrinsics parameters as a structure
 
         """
+        e = ctypes.POINTER(rs_error)()
         _rs_extrinsics = rs_extrinsics()
         lrs.rs_get_device_extrinsics(
             self.dev,
@@ -237,6 +268,7 @@ class DeviceBase(object):
             (double): option value.
         """
         lrs.rs_get_device_option.restype = ctypes.c_double
+        e = ctypes.POINTER(rs_error)()
         return lrs.rs_get_device_option(self.dev, option, ctypes.byref(e))
 
     def get_device_option_description(self, option):
@@ -248,21 +280,22 @@ class DeviceBase(object):
         Returns:
             (str): option value.
         """
-        return pp(lrs.rs_get_device_option_description,
-            self.dev, ctypes.c_uint(option), ctypes.byref(e))
+        e = ctypes.POINTER(rs_error)()
+        return pp(lrs.rs_get_device_option_description, self.dev, ctypes.c_uint(option), ctypes.byref(e))
 
     def set_device_option(self, option, value):
         """Set device option.
-    
+
         Args:
             option (int): taken from :class:`pyrealsense.constants.rs_option`.
             value (double): value to be set for the option.
         """
-        lrs.rs_set_device_option(self.dev,
-            ctypes.c_uint(option), ctypes.c_double(value), ctypes.byref(e))
+        e = ctypes.POINTER(rs_error)()
+        lrs.rs_set_device_option(self.dev, ctypes.c_uint(option), ctypes.c_double(value), ctypes.byref(e))
         _check_error(e)
 
     def _get_stream_intrinsics(self, stream):
+        e = ctypes.POINTER(rs_error)()
         _rs_intrinsics = rs_intrinsics()
         lrs.rs_get_stream_intrinsics(
             self.dev,
@@ -273,24 +306,27 @@ class DeviceBase(object):
 
     def _get_stream_data_closure(self, s):
         def get_stream_data(s):
+            e = ctypes.POINTER(rs_error)()
             lrs.rs_get_frame_data.restype = ndpointer(dtype=s.dtype, shape=s.shape)
             return lrs.rs_get_frame_data(self.dev, s.stream, ctypes.byref(e))
         return lambda x: get_stream_data(s)
 
     def _get_depth_scale(self):
+        e = ctypes.POINTER(rs_error)()
         lrs.rs_get_device_depth_scale.restype = ctypes.c_float
         return lrs.rs_get_device_depth_scale(self.dev, ctypes.byref(e))
 
     def _get_pointcloud(self):
         ds = [s for s in self.streams if type(s) is DepthStream][0]
 
-        lrs.rs_get_frame_data.restype = ndpointer(dtype=ctypes.c_uint16, shape=(ds.height,ds.width))
+        e = ctypes.POINTER(rs_error)()
+        lrs.rs_get_frame_data.restype = ndpointer(dtype=ctypes.c_uint16, shape=(ds.height, ds.width))
         depth = lrs.rs_get_frame_data(self.dev, rs_stream.RS_STREAM_DEPTH, ctypes.byref(e))
 
         pointcloud = np.zeros((ds.height * ds.width * 3), dtype=np.float32)
 
-        ## ugly fix for outliers
-        depth[0,:2] = 0
+        # ugly fix for outliers
+        depth[0, :2] = 0
 
         rsutilwrapper.deproject_depth(pointcloud, self.depth_intrinsics, depth, self.depth_scale)
         return pointcloud.reshape((ds.height, ds.width, 3))
@@ -305,7 +341,7 @@ class DeviceBase(object):
         rsutilwrapper.apply_ivcam_preset(self.dev, preset)
 
     def project_point_to_pixel(self, point):
-        """Project a 3d point to its 2d pixel coordinate by calling rsutil's 
+        """Project a 3d point to its 2d pixel coordinate by calling rsutil's
         rs_project_point_to_pixel under the hood.
 
         Args:
@@ -319,7 +355,7 @@ class DeviceBase(object):
         return pixel
 
     def deproject_pixel_to_point(self, pixel, depth):
-        """Deproject a 2d pixel to its 3d point coordinate by calling rsutil's 
+        """Deproject a 2d pixel to its 3d point coordinate by calling rsutil's
         rs_deproject_pixel_to_point under the hood.
 
         Args:
@@ -332,4 +368,3 @@ class DeviceBase(object):
         point = np.ones(3, dtype=np.float32) * np.NaN
         rsutilwrapper.deproject_pixel_to_point(point, self.depth_intrinsics, pixel, depth)
         return point
-

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -2,16 +2,19 @@ from unittest import TestCase
 import pyrealsense as pyrs
 from pyrealsense.utils import RealsenseError
 
-class Test_0_Start(TestCase):
+
+class Test_Service_Device(TestCase):
     def test_is_started(self):
         try:
-            pyrs.start()
+            service = pyrs.Service()
         except RealsenseError as e:
             self.assertTrue(e.function == 'rs_create_context')
-
-class Test_1_Device(TestCase):
-    def test_is_not_created(self):
-        try:
-            pyrs.Device()
-        except RealsenseError as e:
-            self.assertTrue(e.function == 'rs_get_device')
+        else:
+            try:
+                dev = service.Device()
+            except RealsenseError as e:
+                self.assertTrue(e.function == 'rs_get_device')
+            else:
+                dev.stop()
+            finally:
+                service.stop()

--- a/tests/test_online.py
+++ b/tests/test_online.py
@@ -2,23 +2,29 @@ from unittest import TestCase
 import pyrealsense as pyrs
 import numpy as np
 
+
 class Test_0_Start(TestCase):
     def test_is_started(self):
-        ret = pyrs.start()
-        self.assertTrue(ret == 1)
+        service = pyrs.Service()
+        ret = len(list(service.get_devices()))
+        self.assertTrue(ret > 0)
+        service.stop()
 
 
 class Test_1_Device(TestCase):
     def test_is_not_created(self):
-        cam = pyrs.Device()
+        service = pyrs.Service()
+        cam = service.Device()
         cam.wait_for_frames()
         self.assertTrue(cam.color.any())
         cam.stop()
+        service.stop()
 
 
 class Test_2_Wrapper(TestCase):
     def test_is_wrapped(self):
-        cam = pyrs.Device()
+        service = pyrs.Service()
+        cam = service.Device()
         cam.wait_for_frames()
 
         from pyrealsense import rsutilwrapper
@@ -35,11 +41,13 @@ class Test_2_Wrapper(TestCase):
         rsutilwrapper.project_point_to_pixel(pixel0, cam.depth_intrinsics, point0)
 
         point1 = np.zeros(3, dtype=np.float32)
-        x1,y1 = np.round(pixel0[1]).astype(int), np.round(pixel0[0]).astype(int)
+        x1, y1 = np.round(pixel0[1]).astype(int), np.round(pixel0[0]).astype(int)
 
-        self.assertTrue(np.isclose([x0,y0], [x1,y1], atol=2).all())
+        self.assertTrue(np.isclose([x0, y0], [x1, y1], atol=2).all())
 
-        depth = dm[x0,y0] * cam.depth_scale
+        depth = dm[x0, y0] * cam.depth_scale
         rsutilwrapper.deproject_pixel_to_point(point1, cam.depth_intrinsics, pixel0, depth)
 
         self.assertTrue(np.isclose(point0, point1, atol=10e-3).all())
+        cam.stop()
+        service.stop()


### PR DESCRIPTION
### Motivation
`rs_get_device_count` always returns the same number of devices after initializing `ctx`, i.e. it does not notice when cameras are connected or disconnected. The current implementation uses a single, global context to enumerate and initialize devices. This means one cannot get the current list of connected devices after starting a device. This feature is crucial for applications that allow the user to select from a list of currently connected devices.

### Debugging results
As it turns out, it is possible to start a context `A`, start a device `D` using `A`, initialize a context `B` and `B` will list all currently connected devices, including `D`. This only works as long `A` and `B` were initialized within the same process. If this is not the case `B` will list zero devices.

### Solution
Instead of having a global context, each context gets wrapped in a `Service` object which is also used to initialize devices. Therefore, this PR includes the following major changes:

1. `Service` is responsible to start and stop its own context
2. `Service.get_devices` enumerates all available devices as dictionaries containing the device id, the camera name, serial number and firmware version
3. `Service.device` is a factory function that takes the same args/kwargs as `Device` does currently, but uses its own context to create the device instance.

### Versioning discussion
This is an API breaking change. It is questionable though if it deserves a `3.0` instead of a `2.1`.

I look forward to your feedback.